### PR TITLE
more user instructions for visudo

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -180,6 +180,7 @@ config_check() {
 			echo
 			echo -e " ${BLD}Fix this by adding the following line to ${BLU}/etc/sudoers${NRM}${BLD} to enable this functionality:"${NRM}
 			echo -e "  ${BLD}$user ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper"${NRM}
+			echo -e "Ensure you place the above line BELOW the ${BLD}%sudo ALL=(ALL:ALL) ALL${NRM}${BLD} line"${NRM}
 			exit 1
 		fi
 	fi


### PR DESCRIPTION
order of the lines in visudo *matters*
$user ALL=(ALL) NOPASSWD: /usr/bin/overlay must be placed after the %sudo line

Thanks @jonpolak